### PR TITLE
Add nicer indent marker

### DIFF
--- a/DevastateMini.tmTheme
+++ b/DevastateMini.tmTheme
@@ -30,7 +30,9 @@
                 <key>findHighlightForeground</key>
                 <string>#000000</string>
                 <key>activeGuide</key>
-                <string>#9D550FB0</string>
+                <string>#9D550F</string>
+                <key>stackGuide</key>
+                <string>#9D550FAF</string>
 
                 <key>bracketsForeground</key>
                 <string>#F8F8F2A5</string>


### PR DESCRIPTION
Docs:
http://docs.sublimetext.info/en/latest/reference/color_schemes.html?highlight=indent_guide_options#guides

Before:
![screen shot 2016-07-01 at 08 25 11](https://cloud.githubusercontent.com/assets/3492040/16513765/74675d88-3f67-11e6-981e-df5dc9344945.png)
Now:
![screen shot 2016-07-01 at 08 24 13](https://cloud.githubusercontent.com/assets/3492040/16513767/746d9644-3f67-11e6-8c1c-37f08caf0ef0.png)

Other alternative
![screen shot 2016-07-01 at 08 23 10](https://cloud.githubusercontent.com/assets/3492040/16513766/746b902e-3f67-11e6-9630-c7bcf1f86660.png)
